### PR TITLE
Describe job permissions.

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -2,6 +2,11 @@ name: Build PR
 on:
   pull_request:
     branches: [ "main" ]
+permissions:
+  contents: read
+  checks: write
+  issues: write
+  pull-requests: write
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Granular permissions are always great, specifically here they also simplify the configuration process, as there'll be no need to allow write access in repository settings after creating a repo from the template.